### PR TITLE
Add bulk api v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-salesforce',
-      version='meltano.1.4.27',
+      version='meltano.1.4.28',
       description='Singer.io tap for extracting data from the Salesforce API',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,10 @@
 
 from setuptools import setup
 
-setup(name='tap-salesforce',
-      version='meltano.1.4.28',
+setup(name='bmaquet-tap-salesforce',
+      version='0.0.1',
       description='Singer.io tap for extracting data from the Salesforce API',
-      author='Stitch',
-      url='https://singer.io',
+      author='bmaquet',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_salesforce'],
       install_requires=[

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -174,19 +174,17 @@ def do_discover(sf):
             if field_name == "Id":
                 found_id_field = True
 
-            property_schema, mdata = create_property_schema(
-                f, mdata)
+            property_schema, mdata = create_property_schema(f, mdata)
 
             # Compound Address fields cannot be queried by the Bulk API
-            if f['type'] == "address" and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
-                unsupported_fields.add(
-                    (field_name, 'cannot query compound address fields with bulk API'))
+            if (f['type'] == "address" and sf.api_type in (
+                    tap_salesforce.salesforce.BULK_API_TYPE, tap_salesforce.salesforce.BULK_V2_API_TYPE)):
+                unsupported_fields.add((field_name, 'cannot query compound address fields with bulk API'))
 
             # we haven't been able to observe any records with a json field, so we
             # are marking it as unavailable until we have an example to work with
             if f['type'] == "json":
-                unsupported_fields.add(
-                    (field_name, 'do not currently support json fields - please contact support'))
+                unsupported_fields.add((field_name, 'do not currently support json fields - please contact support'))
 
             # Blacklisted fields are dependent on the api_type being used
             field_pair = (sobject_name, field_name)
@@ -194,18 +192,15 @@ def do_discover(sf):
                 unsupported_fields.add(
                     (field_name, sf.get_blacklisted_fields()[field_pair]))
 
-            inclusion = metadata.get(
-                mdata, ('properties', field_name), 'inclusion')
+            inclusion = metadata.get(mdata, ('properties', field_name), 'inclusion')
 
             if sf.select_fields_by_default and inclusion != 'unsupported':
-                mdata = metadata.write(
-                    mdata, ('properties', field_name), 'selected-by-default', True)
+                mdata = metadata.write(mdata, ('properties', field_name), 'selected-by-default', True)
 
             properties[field_name] = property_schema
 
         if replication_key:
-            mdata = metadata.write(
-                mdata, ('properties', replication_key), 'inclusion', 'automatic')
+            mdata = metadata.write(mdata, ('properties', replication_key), 'inclusion', 'automatic')
 
         # There are cases where compound fields are referenced by the associated
         # subfields but are not actually present in the field list

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -39,7 +39,8 @@ def find_parent(stream):
 
 class Bulk():
 
-    bulk_url = "{}/services/async/41.0/{}"
+    version = '41.0'
+    bulk_url = "{}/services/async/{}/{}"
 
     def __init__(self, sf):
         # Set csv max reading size to the platform's max size available.
@@ -57,7 +58,7 @@ class Bulk():
     # pylint: disable=line-too-long
     def check_bulk_quota_usage(self):
         endpoint = "limits"
-        url = self.sf.data_url.format(self.sf.instance_url, endpoint)
+        url = self.sf.data_url.format(self.sf.instance_url, self.version, endpoint)
 
         with metrics.http_request_timer(endpoint):
             resp = self.sf._make_request('GET', url, headers=self.sf.auth.rest_headers).json()
@@ -145,7 +146,7 @@ class Bulk():
         return batch_status
 
     def _create_job(self, catalog_entry, pk_chunking=False):
-        url = self.bulk_url.format(self.sf.instance_url, "job")
+        url = self.bulk_url.format(self.sf.instance_url, self.version, "job")
         body = {"operation": "queryAll", "object": catalog_entry['stream'], "contentType": "CSV"}
 
         headers = self._get_bulk_headers()
@@ -175,7 +176,7 @@ class Bulk():
 
     def _add_batch(self, catalog_entry, job_id, start_date, order_by_clause=True):
         endpoint = "job/{}/batch".format(job_id)
-        url = self.bulk_url.format(self.sf.instance_url, endpoint)
+        url = self.bulk_url.format(self.sf.instance_url, self.version, endpoint)
 
         body = self.sf._build_query_string(catalog_entry, start_date, order_by_clause=order_by_clause)
 
@@ -219,7 +220,7 @@ class Bulk():
     def job_exists(self, job_id):
         try:
             endpoint = "job/{}".format(job_id)
-            url = self.bulk_url.format(self.sf.instance_url, endpoint)
+            url = self.bulk_url.format(self.sf.instance_url, self.version, endpoint)
             headers = self._get_bulk_headers()
 
             with metrics.http_request_timer("get_job"):
@@ -236,7 +237,7 @@ class Bulk():
 
     def _get_batches(self, job_id):
         endpoint = "job/{}/batch".format(job_id)
-        url = self.bulk_url.format(self.sf.instance_url, endpoint)
+        url = self.bulk_url.format(self.sf.instance_url, self.version, endpoint)
         headers = self._get_bulk_headers()
 
         with metrics.http_request_timer("get_batches"):
@@ -250,7 +251,7 @@ class Bulk():
 
     def _get_batch(self, job_id, batch_id):
         endpoint = "job/{}/batch/{}".format(job_id, batch_id)
-        url = self.bulk_url.format(self.sf.instance_url, endpoint)
+        url = self.bulk_url.format(self.sf.instance_url, self.version, endpoint)
         headers = self._get_bulk_headers()
 
         with metrics.http_request_timer("get_batch"):
@@ -265,7 +266,7 @@ class Bulk():
         CSV lines yielding each line as a record."""
         headers = self._get_bulk_headers()
         endpoint = "job/{}/batch/{}/result".format(job_id, batch_id)
-        url = self.bulk_url.format(self.sf.instance_url, endpoint)
+        url = self.bulk_url.format(self.sf.instance_url, self.version, endpoint)
 
         with metrics.http_request_timer("batch_result_list") as timer:
             timer.tags['sobject'] = catalog_entry['stream']
@@ -280,7 +281,7 @@ class Bulk():
 
         for result in batch_result_list['result']:
             endpoint = "job/{}/batch/{}/result/{}".format(job_id, batch_id, result)
-            url = self.bulk_url.format(self.sf.instance_url, endpoint)
+            url = self.bulk_url.format(self.sf.instance_url, self.version, endpoint)
             headers['Content-Type'] = 'text/csv'
 
             with tempfile.NamedTemporaryFile(mode="w+", encoding="utf8") as csv_file:
@@ -303,7 +304,7 @@ class Bulk():
 
     def _close_job(self, job_id):
         endpoint = "job/{}".format(job_id)
-        url = self.bulk_url.format(self.sf.instance_url, endpoint)
+        url = self.bulk_url.format(self.sf.instance_url, self.version, endpoint)
         body = {"state": "Closed"}
 
         with metrics.http_request_timer("close_job"):

--- a/tap_salesforce/salesforce/bulk_V2.py
+++ b/tap_salesforce/salesforce/bulk_V2.py
@@ -1,0 +1,96 @@
+import csv
+import json
+import sys
+import time
+import tempfile
+import singer
+from singer import metrics
+from tap_salesforce.salesforce.exceptions import (TapSalesforceException)
+
+JOB_STATUS_POLLING_SLEEP = 20
+ITER_CHUNK_SIZE = 1024
+
+LOGGER = singer.get_logger()
+
+
+class BulkV2:
+
+    bulk_V2_url = "{}/services/data/v51.0/{}"
+
+
+    def __init__(self, sf):
+        csv.field_size_limit(sys.maxsize)
+        self.sf = sf
+
+
+    def query(self, catalog_entry, state):
+        job_id = self._create_job(catalog_entry, state)
+        for result in self._get_job_results(job_id):
+            yield result
+        self.sf.jobs_completed += 1
+
+
+    def _get_job_results(self, job_id):
+        job_status = self._poll_on_job_status(job_id)
+        if job_status['state'] in ('Failed', 'Aborted'):
+            raise TapSalesforceException(job_status)
+        else:
+            url = self.bulk_V2_url.format(self.sf.instance_url, "jobs/query/{}/results".format(job_id))
+            headers = self.sf.auth.rest_headers
+            resp = self.sf._make_request('GET', url, headers=headers, stream=True)
+            resp_headers = resp.headers
+            for rec in self._yield_records(resp):
+                yield rec
+            while resp_headers['Sforce-Locator'] != 'null':
+                url = self.bulk_V2_url.format(
+                    self.sf.instance_url, "jobs/query/{}/results?locator={}".format(job_id, resp_headers['Sforce-Locator'])
+                )
+                resp = self.sf._make_request('GET', url, headers=headers, stream=True)
+                resp_headers = resp.headers
+                for rec in self._yield_records(resp):
+                    yield rec
+
+
+    def _yield_records(self, resp):
+        with tempfile.NamedTemporaryFile(mode="w+", encoding="utf8") as csv_file:
+            for chunk in resp.iter_content(chunk_size=ITER_CHUNK_SIZE, decode_unicode=True):
+                if chunk:
+                    # Replace any NULL bytes in the chunk so it can be safely given to the CSV reader
+                    csv_file.write(chunk.replace('\0', ''))
+
+            csv_file.seek(0)
+            csv_reader = csv.reader(csv_file, delimiter=',', quotechar='"')
+            column_name_list = next(csv_reader)
+            for line in csv_reader:
+                rec = dict(zip(column_name_list, line))
+                yield rec
+
+    def _poll_on_job_status(self, job_id):
+        job_status = self._get_job_status(job_id=job_id)
+        while job_status['state'] not in ['JobComplete', 'Failed', 'Aborted']:
+            time.sleep(JOB_STATUS_POLLING_SLEEP)
+            job_status = self._get_job_status(job_id=job_id)
+        return job_status
+
+
+    def _get_job_status(self, job_id):
+        url = self.bulk_V2_url.format(self.sf.instance_url, "jobs/query/{}".format(job_id))
+        headers = self.sf.auth.rest_headers
+        resp = self.sf._make_request('GET', url, headers=headers)
+        resp_json = resp.json()
+        return resp_json
+
+
+    def _create_job(self, catalog_entry, state):
+        url = self.bulk_V2_url.format(self.sf.instance_url, "jobs/query")
+        start_date = self.sf.get_start_date(state, catalog_entry)
+        query = self.sf._build_query_string(catalog_entry, start_date)
+        body = {"operation": "queryAll", "query": query, "contentType": "CSV"}
+        headers = self.sf.auth.rest_headers
+        headers["Content-Type"] = "application/json"
+
+        with metrics.http_request_timer("create_job") as timer:
+            timer.tags['sobject'] = catalog_entry['stream']
+            resp = self.sf._make_request('POST', url, headers=headers, body=json.dumps(body))
+        job = resp.json()
+        return job['id']


### PR DESCRIPTION
Adding support for Salesforce Bulk V2 API.

- Adding a new `BULK_V2_API_TYPE`, which can be used by setting `BULK_V2` as `api_type` in the config
- Bumping the API version to `51.0` for Bulk V2 API, while keeping `41.0` on the other two API types
- In Bulk V2, preventing the use of `ORDER BY` clause in SOQL queries because this creates issues https://help.salesforce.com/articleView?id=000353741&language=en_US&mode=1&type=1. I'm ensuring the state keeps the latest fetched records using a new `max_replication_key_value` variable.
- Adding a new connection type `OAuthPasswordCredentials` which uses a combination of `username`, `password`, `client_id`, and `client_secret`.