### PR TITLE
Add end date to BULK_V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ pip install git+https://gitlab.com/meltano/tap-salesforce.git
 ```
 {
   "start_date": "2017-11-02T00:00:00Z",
+  "end_date": "2017-12-02T00:00:00Z",
   "state_message_threshold": 1000,
   "max_workers": 8
 }
@@ -76,6 +77,8 @@ pip install git+https://gitlab.com/meltano/tap-salesforce.git
 The `client_id` and `client_secret` keys are your OAuth Salesforce App secrets. The `refresh_token` is a secret created during the OAuth flow. For more info on the Salesforce OAuth flow, visit the [Salesforce documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_understanding_web_server_oauth_flow.htm).
 
 The `start_date` is used by the tap as a bound on SOQL queries when searching for records.  This should be an [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) formatted date-time, like "2018-01-08T00:00:00Z". For more details, see the [Singer best practices for dates](https://github.com/singer-io/getting-started/blob/master/BEST_PRACTICES.md#dates).
+
+The `end_date` is used by the tap as a bound on SOQL queries when searching for records. Same formatting restrictions as `start_date` applies.
 
 The `api_type` is used to switch the behavior of the tap between using Salesforce's "REST" and "BULK" APIs. When new fields are discovered in Salesforce objects, the `select_fields_by_default` key describes whether or not the tap will select those fields by default.
 

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -42,7 +42,8 @@ CONFIG = {
     'refresh_token': None,
     'client_id': None,
     'client_secret': None,
-    'start_date': None
+    'start_date': None,
+    'end_date': None
 }
 
 FORCED_FULL_TABLE = {
@@ -389,6 +390,7 @@ def main_impl():
             is_sandbox=CONFIG.get('is_sandbox'),
             select_fields_by_default=CONFIG.get('select_fields_by_default'),
             default_start_date=CONFIG.get('start_date'),
+            end_date=CONFIG.get('end_date'),
             api_type=CONFIG.get('api_type'))
         sf.login()
 

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -202,6 +202,7 @@ class Salesforce():
                  is_sandbox=None,
                  select_fields_by_default=None,
                  default_start_date=None,
+                 end_date=None,
                  api_type=None):
         self.api_type = api_type.upper() if api_type else None
         self.session = requests.Session()
@@ -215,6 +216,7 @@ class Salesforce():
         self.is_sandbox = is_sandbox is True or (isinstance(is_sandbox, str) and is_sandbox.lower() == 'true')
         self.select_fields_by_default = select_fields_by_default is True or (isinstance(select_fields_by_default, str) and select_fields_by_default.lower() == 'true')
         self.default_start_date = default_start_date
+        self.end_date = end_date
         self.rest_requests_attempted = 0
         self.jobs_completed = 0
         self.data_url = "{}/services/data/v{}/{}"

--- a/tap_salesforce/salesforce/bulk_V2.py
+++ b/tap_salesforce/salesforce/bulk_V2.py
@@ -25,6 +25,7 @@ class BulkV2:
 
 
     def query(self, catalog_entry, state):
+        end_date = catalog_entry
         job_id = self._create_job(catalog_entry, state)
         for result in self._get_job_results(job_id):
             yield result
@@ -85,7 +86,7 @@ class BulkV2:
     def _create_job(self, catalog_entry, state):
         url = self.BULK_V2_URL.format(self.sf.instance_url, self.BULK_V2_API_VERSION, "jobs/query")
         start_date = self.sf.get_start_date(state, catalog_entry)
-        query = self.sf._build_query_string(catalog_entry, start_date)
+        query = self.sf._build_query_string(catalog_entry, start_date, self.sf.end_date)
         body = {"operation": "queryAll", "query": query, "contentType": "CSV"}
         headers = self.sf.auth.rest_headers
         headers["Content-Type"] = "application/json"


### PR DESCRIPTION
Exposing `end_date` tap configuration to refine Salesforce's `SOQL` query builder filtering capabilities. 