### PR TITLE
Update max replication value logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 This is a forked version of [tap-salesforce (meltano.1.4.27)](https://gitlab.com/meltano/tap-salesforce) that maintained by [bmaquet](https://github.com/BenjMaq).
 
 Main differences from the Meltano version:
+
 - Support a new `OAuthPasswordCredentials` authentication which uses a combination of `username`, `password`, `client_id`, and `client_secret`.
 - Support Salesforce BULK API V2
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@
 
 [Singer](https://www.singer.io/) tap that extracts data from a [Salesforce](https://www.salesforce.com/) Account and produces JSON-formatted data following the [Singer spec](https://github.com/singer-io/getting-started/blob/master/SPEC.md).
 
-This is a forked version of [tap-salesforce (meltano.1.4.27)](https://gitlab.com/meltano/tap-salesforce) that maintained by [bmaquet](https://github.com/BenjMaq).
+This is a forked version of [tap-salesforce (v1.4.24)](https://github.com/singer-io/tap-salesforce) that maintained by the Meltano team.
 
-Main differences from the Meltano version:
+Main differences from the original version:
 
+- Support for `username/password/security_token` authentication
+- Support for concurrent execution (8 threads by default) when accessing different API endpoints to speed up the extraction process
 - Support a new `OAuthPasswordCredentials` authentication which uses a combination of `username`, `password`, `client_id`, and `client_secret`.
 - Support Salesforce BULK API V2
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@
 
 [Singer](https://www.singer.io/) tap that extracts data from a [Salesforce](https://www.salesforce.com/) Account and produces JSON-formatted data following the [Singer spec](https://github.com/singer-io/getting-started/blob/master/SPEC.md).
 
-This is a forked version of [tap-salesforce (v1.4.24)](https://github.com/singer-io/tap-salesforce) that maintained by the Meltano team.
+This is a forked version of [tap-salesforce (meltano.1.4.27)](https://gitlab.com/meltano/tap-salesforce) that maintained by [bmaquet](https://github.com/BenjMaq).
 
-Main differences from the original version:
-
-- Support for `username/password/security_token` authentication
-- Support for concurrent execution (8 threads by default) when accessing different API endpoints to speed up the extraction process
+Main differences from the Meltano version:
 - Support a new `OAuthPasswordCredentials` authentication which uses a combination of `username`, `password`, `client_id`, and `client_secret`.
 - Support Salesforce BULK API V2
 

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,11 @@
 
 from setuptools import setup
 
-setup(name='bmaquet-tap-salesforce',
-      version='0.0.10',
+setup(name='tap-salesforce',
+      version='meltano.1.4.28',
       description='Singer.io tap for extracting data from the Salesforce API',
-      author='bmaquet',
+      author='Stitch',
+      url='https://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_salesforce'],
       install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,10 @@
 
 from setuptools import setup
 
-setup(name='tap-salesforce',
-      version='meltano.1.4.28',
+setup(name='bmaquet-tap-salesforce',
+      version='0.0.11',
       description='Singer.io tap for extracting data from the Salesforce API',
-      author='Stitch',
-      url='https://singer.io',
+      author='bmaquet',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_salesforce'],
       install_requires=[

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -133,7 +133,8 @@ def sync_records(sf, catalog_entry, state, counter, state_msg_threshold):
 
         replication_key_value = replication_key and singer_utils.strptime_with_tz(rec[replication_key])
 
-        if max_replication_key_value is None or rec[replication_key] > max_replication_key_value:
+        end_date = sf.end_date if sf.end_date is not None else start_time
+        if max_replication_key_value is None or (max_replication_key_value < rec[replication_key] <= end_date):
             max_replication_key_value = rec[replication_key]
 
         if sf.pk_chunking:

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -148,22 +148,14 @@ def sync_records(sf, catalog_entry, state, counter, state_msg_threshold):
 
                 if counter.value % state_msg_threshold == 0:
                     singer.write_state(state)
-        # Before writing a bookmark, make sure Salesforce has not given us a
-        # record with one outside our range
-        elif replication_key_value and replication_key_value <= start_time:
-            # For BULK_V2, we keep the state of the record with the latest replication_key value
-            if sf.api_type == 'BULK_V2':
-                state = singer.write_bookmark(
-                    state,
-                    catalog_entry['tap_stream_id'],
-                    replication_key,
-                    max_replication_key_value)
-            else:
-                state = singer.write_bookmark(
-                    state,
-                    catalog_entry['tap_stream_id'],
-                    replication_key,
-                    rec[replication_key])
+        # Before writing a bookmark, make sure Salesforce has not given us a record with one outside our range
+        # Also, do not write a bookmark for BULK_V2 API. We only write at the end of the stream
+        elif sf.api_type != 'BULK_V2' and replication_key_value and replication_key_value <= start_time:
+            state = singer.write_bookmark(
+                state,
+                catalog_entry['tap_stream_id'],
+                replication_key,
+                rec[replication_key])
 
             if counter.value % state_msg_threshold == 0:
                 singer.write_state(state)
@@ -183,6 +175,15 @@ def sync_records(sf, catalog_entry, state, counter, state_msg_threshold):
             catalog_entry['tap_stream_id'],
             replication_key,
             singer_utils.strftime(chunked_bookmark))
+
+    # For BULK_V2, we keep the state of the record with the latest replication_key value.
+    # We only write a bookmark at the end of the stream to prevent false-resumes
+    if sf.api_type == 'BULK_V2':
+        state = singer.write_bookmark(
+            state,
+            catalog_entry['tap_stream_id'],
+            replication_key,
+            max_replication_key_value)
 
 def fix_record_anytype(rec, schema):
     """Modifies a record when the schema has no 'type' element due to a SF type of 'anyType.'


### PR DESCRIPTION
- Make sure `rec[replication_key]` cannot be > `sf.end_date` if specified
- Only write state at the end of the stream, making sure we don't have false-resumes, since the stream is not ordered